### PR TITLE
Fix for new nuget schema requiring 2 requests.

### DIFF
--- a/build/download.rs
+++ b/build/download.rs
@@ -7,6 +7,7 @@ use std::{
     path::{Path, PathBuf},
     str::FromStr,
 };
+use std::fmt::format;
 
 use build_target::{Arch, Env, Os};
 use semver::Version;
@@ -29,15 +30,19 @@ struct Resource<'a> {
 #[derive(Debug, Serialize, Deserialize)]
 struct PackageInfoIndex<'a> {
     #[serde(rename = "items")]
-    pages: Vec<PackageInfoCatalogPage<'a>>,
+    pages: Vec<PackageInfoCatalogPageReference<'a>>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-struct PackageInfoCatalogPage<'a> {
+struct PackageInfoCatalogPageReference<'a> {
     #[serde(rename = "@id")]
     url: Cow<'a, str>,
     lower: Cow<'a, str>,
     upper: Cow<'a, str>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct PackageInfoCatalogPage<'a> {
     items: Vec<PackageInfoCatalogPageEntry<'a>>,
 }
 
@@ -121,7 +126,14 @@ pub fn download_nethost(target: &str, target_path: &Path) -> Result<(), Box<dyn 
         .pages
         .into_iter()
         .max_by_key(|page| Version::from_str(page.upper.as_ref()).unwrap())
-        .expect("Unable to find package page.")
+        .expect("Unable to find package page.");
+
+    let package_page = client
+        .get(format!("{}", package_info.url))
+        .send()
+        .expect("Failed to retrieve package page.")
+        .json::<PackageInfoCatalogPage>()
+        .expect("Failed to parse json page response from nuget.org.")
         .items
         .into_iter()
         .map(|e| e.inner)
@@ -130,7 +142,7 @@ pub fn download_nethost(target: &str, target_path: &Path) -> Result<(), Box<dyn 
         .unwrap();
 
     let mut package_content_response = client
-        .get(package_info.content.as_ref())
+        .get(package_page.content.as_ref())
         .send()
         .expect("Failed to download nethost nuget package.");
 

--- a/build/download.rs
+++ b/build/download.rs
@@ -7,7 +7,6 @@ use std::{
     path::{Path, PathBuf},
     str::FromStr,
 };
-use std::fmt::format;
 
 use build_target::{Arch, Env, Os};
 use semver::Version;


### PR DESCRIPTION
As per issue #2

Nuget seems to have a new schema where each items page does not have the required content url information anymore and failed to compile. Requests need to be split into retrieving the page reference and then grabbing the page items from the url.

`https://api.nuget.org/v3/index.json`
```json
    {
      "@id": "https://api.nuget.org/v3/registration5-semver1/",
      "@type": "RegistrationsBaseUrl",
      "comment": "Base URL of Azure storage where NuGet package registration info is stored"
    },
 ```

`https://api.nuget.org/v3/registration5-semver1/runtime.win-x64.microsoft.netcore.dotnetapphost/index.json`
```json
{
    "@id": "https://api.nuget.org/v3/registration5-semver1/runtime.win-x64.microsoft.netcore.dotnetapphost/index.json",
    "@type": [
        "catalog:CatalogRoot",
        "PackageRegistration",
        "catalog:Permalink"
    ],
    "commitId": "d5bd1a13-1385-4fd6-b61b-5c7cb58df011",
    "commitTimeStamp": "2022-10-11T14:09:08.5390654+00:00",
    "count": 3,
    "items": [
        {
            "@id": "https://api.nuget.org/v3/registration5-semver1/runtime.win-x64.microsoft.netcore.dotnetapphost/page/2.0.0-preview1-002111-00/3.0.0-preview9-19423-09.json",
            "@type": "catalog:CatalogPage",
            "commitId": "876491f7-776a-4254-8d75-b70bbd0cad77",
            "commitTimeStamp": "2022-10-11T13:45:41.1829817+00:00",
            "count": 64,
            "lower": "2.0.0-preview1-002111-00",
            "upper": "3.0.0-preview9-19423-09"
        },
        {
            "@id": "https://api.nuget.org/v3/registration5-semver1/runtime.win-x64.microsoft.netcore.dotnetapphost/page/3.0.0-rc1-19456-20/6.0.9.json",
            "@type": "catalog:CatalogPage",
            "commitId": "876491f7-776a-4254-8d75-b70bbd0cad77",
            "commitTimeStamp": "2022-10-11T13:45:41.1829817+00:00",
            "count": 64,
            "lower": "3.0.0-rc1-19456-20",
            "upper": "6.0.9"
        },
        {
            "@id": "https://api.nuget.org/v3/registration5-semver1/runtime.win-x64.microsoft.netcore.dotnetapphost/page/6.0.10/6.0.10.json",
            "@type": "catalog:CatalogPage",
            "commitId": "d5bd1a13-1385-4fd6-b61b-5c7cb58df011",
            "commitTimeStamp": "2022-10-11T14:09:08.5390654+00:00",
            "count": 1,
            "lower": "6.0.10",
            "upper": "6.0.10"
        }
    ],
    "@context": {
        "@vocab": "http://schema.nuget.org/schema#",
        "catalog": "http://schema.nuget.org/catalog#",
        "xsd": "http://www.w3.org/2001/XMLSchema#",
        "items": {
            "@id": "catalog:item",
            "@container": "@set"
        },
        "commitTimeStamp": {
            "@id": "catalog:commitTimeStamp",
            "@type": "xsd:dateTime"
        },
        "commitId": {
            "@id": "catalog:commitId"
        },
        "count": {
            "@id": "catalog:count"
        },
        "parent": {
            "@id": "catalog:parent",
            "@type": "@id"
        },
        "tags": {
            "@id": "tag",
            "@container": "@set"
        },
        "reasons": {
            "@container": "@set"
        },
        "packageTargetFrameworks": {
            "@id": "packageTargetFramework",
            "@container": "@set"
        },
        "dependencyGroups": {
            "@id": "dependencyGroup",
            "@container": "@set"
        },
        "dependencies": {
            "@id": "dependency",
            "@container": "@set"
        },
        "packageContent": {
            "@type": "@id"
        },
        "published": {
            "@type": "xsd:dateTime"
        },
        "registration": {
            "@type": "@id"
        }
    }
}
```

`https://api.nuget.org/v3/registration5-semver1/runtime.win-x64.microsoft.netcore.dotnetapphost/page/6.0.10/6.0.10.json`
```json
{
    "@id": "https://api.nuget.org/v3/registration5-semver1/runtime.win-x64.microsoft.netcore.dotnetapphost/page/6.0.10/6.0.10.json",
    "@type": "catalog:CatalogPage",
    "commitId": "d5bd1a13-1385-4fd6-b61b-5c7cb58df011",
    "commitTimeStamp": "2022-10-11T14:09:08.5390654+00:00",
    "count": 1,
    "items": [
        {
            "@id": "https://api.nuget.org/v3/registration5-semver1/runtime.win-x64.microsoft.netcore.dotnetapphost/6.0.10.json",
            "@type": "Package",
            "commitId": "d5bd1a13-1385-4fd6-b61b-5c7cb58df011",
            "commitTimeStamp": "2022-10-11T14:09:08.5390654+00:00",
            "catalogEntry": {
                "@id": "https://api.nuget.org/v3/catalog0/data/2022.10.11.14.03.10/runtime.win-x64.microsoft.netcore.dotnetapphost.6.0.10.json",
                "@type": "PackageDetails",
                "authors": "Microsoft",
                "description": "Internal implementation package not meant for direct consumption. Please do not reference directly. \nProvides the .NET app bootstrapper intended for use in the application directory",
                "iconUrl": "https://api.nuget.org/v3-flatcontainer/runtime.win-x64.microsoft.netcore.dotnetapphost/6.0.10/icon",
                "id": "runtime.win-x64.Microsoft.NETCore.DotNetAppHost",
                "language": "",
                "licenseExpression": "MIT",
                "licenseUrl": "https://www.nuget.org/packages/runtime.win-x64.Microsoft.NETCore.DotNetAppHost/6.0.10/license",
                "listed": true,
                "minClientVersion": "2.12",
                "packageContent": "https://api.nuget.org/v3-flatcontainer/runtime.win-x64.microsoft.netcore.dotnetapphost/6.0.10/runtime.win-x64.microsoft.netcore.dotnetapphost.6.0.10.nupkg",
                "projectUrl": "https://dot.net/",
                "published": "2022-10-11T13:41:05.457+00:00",
                "requireLicenseAcceptance": false,
                "summary": "",
                "tags": [
                    ""
                ],
                "title": "runtime.win-x64.Microsoft.NETCore.DotNetAppHost",
                "version": "6.0.10"
            },
            "packageContent": "https://api.nuget.org/v3-flatcontainer/runtime.win-x64.microsoft.netcore.dotnetapphost/6.0.10/runtime.win-x64.microsoft.netcore.dotnetapphost.6.0.10.nupkg",
            "registration": "https://api.nuget.org/v3/registration5-semver1/runtime.win-x64.microsoft.netcore.dotnetapphost/index.json"
        }
    ],
    "parent": "https://api.nuget.org/v3/registration5-semver1/runtime.win-x64.microsoft.netcore.dotnetapphost/index.json",
    "lower": "6.0.10",
    "upper": "6.0.10",
    "@context": {
        "@vocab": "http://schema.nuget.org/schema#",
        "catalog": "http://schema.nuget.org/catalog#",
        "xsd": "http://www.w3.org/2001/XMLSchema#",
        "items": {
            "@id": "catalog:item",
            "@container": "@set"
        },
        "commitTimeStamp": {
            "@id": "catalog:commitTimeStamp",
            "@type": "xsd:dateTime"
        },
        "commitId": {
            "@id": "catalog:commitId"
        },
        "count": {
            "@id": "catalog:count"
        },
        "parent": {
            "@id": "catalog:parent",
            "@type": "@id"
        },
        "tags": {
            "@id": "tag",
            "@container": "@set"
        },
        "reasons": {
            "@container": "@set"
        },
        "packageTargetFrameworks": {
            "@id": "packageTargetFramework",
            "@container": "@set"
        },
        "dependencyGroups": {
            "@id": "dependencyGroup",
            "@container": "@set"
        },
        "dependencies": {
            "@id": "dependency",
            "@container": "@set"
        },
        "packageContent": {
            "@type": "@id"
        },
        "published": {
            "@type": "xsd:dateTime"
        },
        "registration": {
            "@type": "@id"
        }
    }
}
```