### PR TITLE
Replace `reqwest` with `ureq`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,11 @@ coreclr-hosting-shared = "0.1"
 [build-dependencies]
 build-target = "0.8"
 cargo-emit = "0.2"
-reqwest = { version = "0.12", features = ["blocking", "json", "rustls-tls"], default-features = false, optional = true }
+ureq = { version = "3.1", features = ["json"], optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
 semver = { version = "1.0", optional = true }
 zip = { version = "4.3", optional = true }
 
 [features]
-download-nuget = ["reqwest", "serde", "serde_json", "semver", "zip"]
+download-nuget = ["ureq", "serde", "serde_json", "semver", "zip"]


### PR DESCRIPTION
I noticed the build script uses `reqwest`, a rather heavyweight and async-first library, for what is only a few simple blocking calls. This PR replaces `reqwest` with `ureq`, which much more lightweight and is designed primarily for these sorts of simple use cases. This removes a bunch of transitive deps (~60 or so, including all of Tokio) and also reduces compile times by a decent amount.